### PR TITLE
Load Save Menu partial click functionality and load world skeleton

### DIFF
--- a/src/loadSaveMenu.c
+++ b/src/loadSaveMenu.c
@@ -1,0 +1,96 @@
+#include "loadSaveMenu.h"
+#include <GL/glut.h>
+#include <GL/freeglut.h>
+
+void renderLoadButtonBackground(void)
+{
+glColor3f (0.5, 0.5, 0.5);
+glBegin(GL_POLYGON);
+glVertex3f (0.30, 0.60, 0.0);
+glVertex3f (0.65, 0.60, 0.0);
+glVertex3f (0.65, 0.75, 0.0);
+glVertex3f (0.30, 0.75, 0.0);
+glEnd();
+}
+
+void renderLoadSaveMenu(void){
+    glClearColor(0.0f, 0.0f, 0.0f, 0.5f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    glLoadIdentity();
+    glutSwapBuffers();
+    glOrtho(0.0, 1.0, 0.0, 1.0, -1.0, 1.0);
+    glMatrixMode(GL_MODELVIEW);
+    glLoadIdentity();
+
+    //creates the title
+    glPushMatrix();
+    glLoadIdentity();
+    glColor3f(1.0f,1.0f,1.0f);
+    glRasterPos2f(0.42, 0.90);
+    glutBitmapString(GLUT_BITMAP_TIMES_ROMAN_24, "Choose Save To Load");
+    glPopMatrix();
+
+//back button
+    glPushMatrix();
+    glTranslatef(-0.2, 0.3, 0.0);
+    glColor3f (0.5, 0.5, 0.5);
+    glBegin(GL_POLYGON);
+    glVertex3f (0.25, 0.60, 0.0);
+    glVertex3f (0.35, 0.60, 0.0);
+    glVertex3f (0.35, 0.65, 0.0);
+    glVertex3f (0.25, 0.65, 0.0);
+    glEnd();
+    glPopMatrix();
+
+//back button text
+    glPushMatrix();
+    glLoadIdentity();
+    glColor3f(1.0f,1.0f,1.0f);
+    glRasterPos2f(0.09, 0.92);
+    glutBitmapString(GLUT_BITMAP_TIMES_ROMAN_24, "Back");
+    glPopMatrix();
+
+//first button
+    glPushMatrix();
+    glTranslatef(0.0, 0.1, 0.0);
+    renderLoadButtonBackground();
+    glPopMatrix();
+
+//first button text
+    glPushMatrix();
+    glLoadIdentity();
+    glColor3f(1.0f,1.0f,1.0f);
+    glRasterPos2f(0.45, 0.76);
+    glutBitmapString(GLUT_BITMAP_TIMES_ROMAN_24, "World 1");
+    glPopMatrix();
+
+//second button
+    glPushMatrix();
+    glTranslatef(0.0, -0.2, 0.0);
+    renderLoadButtonBackground();
+    glPopMatrix();
+
+//second button text
+    glPushMatrix();
+    glLoadIdentity();
+    glColor3f(1.0f,1.0f,1.0f);
+    glRasterPos2f(0.45, 0.46);
+    glutBitmapString(GLUT_BITMAP_TIMES_ROMAN_24, "World 2");
+    glPopMatrix();
+
+//third button
+    glPushMatrix();
+    glTranslatef(0.0, -0.5, 0.0);
+    renderLoadButtonBackground();
+    glPopMatrix();
+
+//third buton text
+    glPushMatrix();
+    glLoadIdentity();
+    glColor3f(1.0f,1.0f,1.0f);
+    glRasterPos2f(0.45, 0.16);
+    glutBitmapString(GLUT_BITMAP_TIMES_ROMAN_24, "World 3");
+    glPopMatrix();
+
+    glutSwapBuffers();
+}

--- a/src/loadSaveMenu.h
+++ b/src/loadSaveMenu.h
@@ -1,0 +1,2 @@
+void renderLoadButtonBackground();
+void renderLoadSaveMenu();

--- a/src/main.c
+++ b/src/main.c
@@ -157,9 +157,10 @@ typedef struct {
 } Model;
 
 static int launchCraft;
-//TODO:will be used as an additional check for the load save menu so it will
+//used as an additional check for the load save menu so it will
 //fire the correct events on click and not the ones for main menu
 static int loadSaveMenuLaunched;
+static int disableMainMenuClicks;
 static Model model;
 static Model *g = &model;
 
@@ -2679,12 +2680,16 @@ void reset_model() {
     g->time_changed = 1;
 }
 
-//determines the location a user clicked with their mouse so we can call the button methods
+/** handles a users mouse click by getting the position of their click then executing an appropriate response
+*/
 void handleMouseClick(int button, int state,int x, int y){
     //we float the values by screen height and width so we can fit them within our
     //ortho matrix
     float x1=x/(float)glutGet(GLUT_SCREEN_WIDTH);
     float y1=y/(float)glutGet(GLUT_SCREEN_HEIGHT);
+    printf("x: %f \n",x1);
+     printf("y: %f \n",y1);
+    if(!loadSaveMenuLaunched){
     if(((x1>=0.3 && x1<=0.65)&&(y1>=0.15 && y1<=0.3))){
         launchCraft=1;
         printf("Launch Craft Called \n");
@@ -2693,11 +2698,46 @@ void handleMouseClick(int button, int state,int x, int y){
     if(((x1>=0.3 && x1<=0.65)&&(y1>=0.45 && y1<=0.6))){
         //TODO: clear the glut window and render a new screen that will allow the user to choose a saved world or start a new one
         printf("Load Save Called \n");
+        x1=0;
+        y1=0;
         renderLoadSaveMenu();
+        loadSaveMenuLaunched=1;
     }
     if(((x1>=0.3 && x1<=0.65)&&(y1>=0.75 && y1<=0.9))){
          printf("Exit Called \n");
         exit(0);
+    }
+    //loadSaveMenuLaunched ensures we won't call any main menu clicks while on load save
+    }else if(loadSaveMenuLaunched){
+        //we need this boolean as clicking in GLUT happens in two parts onclick and on release
+        //becasue of this this method gets called twice on the menu and this boolean ensures we aren't immediately
+        //loading a world when clicking load save
+        if(disableMainMenuClicks){
+        if(((x1>=0.05 && x1<=0.15)&&(y1>=0.01 && y1<=0.4))){
+            //back
+            printf("back called \n");
+            renderMainMenu();
+            loadSaveMenuLaunched=0;
+            disableMainMenuClicks=0;
+        }
+        if(((x1>=0.3 && x1<=0.65)&&(y1>=0.15 && y1<=0.3))){
+            //World1
+             launchCraft=1;
+             printf("Load World 1 \n");
+             glutLeaveMainLoop();
+            
+        }
+        if(((x1>=0.3 && x1<=0.65)&&(y1>=0.45 && y1<=0.6))){
+            //world2
+            printf("Load World 2 \n");
+        }
+        if(((x1>=0.3 && x1<=0.65)&&(y1>=0.75 && y1<=0.9))){
+            //world3
+            printf("Load World 3 \n");
+        }
+        }else{
+            disableMainMenuClicks=1;
+        }
     }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -2661,102 +2661,6 @@ void reset_model() {
     g->time_changed = 1;
 }
 
-void renderLoadButtonBackground(void)
-{
-glColor3f (0.5, 0.5, 0.5);
-glBegin(GL_POLYGON);
-glVertex3f (0.30, 0.60, 0.0);
-glVertex3f (0.65, 0.60, 0.0);
-glVertex3f (0.65, 0.75, 0.0);
-glVertex3f (0.30, 0.75, 0.0);
-glEnd();
-}
-
-void renderLoadSaveMenu(void){
-    glClearColor(0.0f, 0.0f, 0.0f, 0.5f);
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    glLoadIdentity();
-    glutSwapBuffers();
-    glOrtho(0.0, 1.0, 0.0, 1.0, -1.0, 1.0);
-    glMatrixMode(GL_MODELVIEW);
-    glLoadIdentity();
-
-    //creates the title
-    glPushMatrix();
-    glLoadIdentity();
-    glColor3f(1.0f,1.0f,1.0f);
-    glRasterPos2f(0.42, 0.90);
-    glutBitmapString(GLUT_BITMAP_TIMES_ROMAN_24, "Choose Save To Load");
-    glPopMatrix();
-
-//back button
-    glPushMatrix();
-    glTranslatef(-0.2, 0.3, 0.0);
-    glColor3f (0.5, 0.5, 0.5);
-    glBegin(GL_POLYGON);
-    glVertex3f (0.25, 0.60, 0.0);
-    glVertex3f (0.35, 0.60, 0.0);
-    glVertex3f (0.35, 0.65, 0.0);
-    glVertex3f (0.25, 0.65, 0.0);
-    glEnd();
-    glPopMatrix();
-
-//back button text
-    glPushMatrix();
-    glLoadIdentity();
-    glColor3f(1.0f,1.0f,1.0f);
-    glRasterPos2f(0.09, 0.92);
-    glutBitmapString(GLUT_BITMAP_TIMES_ROMAN_24, "Back");
-    glPopMatrix();
-
-//first button
-    glPushMatrix();
-    glTranslatef(0.0, 0.1, 0.0);
-    renderLoadButtonBackground();
-    glPopMatrix();
-
-//first button text
-    glPushMatrix();
-    glLoadIdentity();
-    glColor3f(1.0f,1.0f,1.0f);
-    glRasterPos2f(0.45, 0.76);
-    glutBitmapString(GLUT_BITMAP_TIMES_ROMAN_24, "World 1");
-    glPopMatrix();
-
-//second button
-    glPushMatrix();
-    glTranslatef(0.0, -0.2, 0.0);
-    renderLoadButtonBackground();
-    glPopMatrix();
-
-//second button text
-    glPushMatrix();
-    glLoadIdentity();
-    glColor3f(1.0f,1.0f,1.0f);
-    glRasterPos2f(0.45, 0.46);
-    glutBitmapString(GLUT_BITMAP_TIMES_ROMAN_24, "World 2");
-    glPopMatrix();
-
-//third button
-    glPushMatrix();
-    glTranslatef(0.0, -0.5, 0.0);
-    renderLoadButtonBackground();
-    glPopMatrix();
-
-//third buton text
-    glPushMatrix();
-    glLoadIdentity();
-    glColor3f(1.0f,1.0f,1.0f);
-    glRasterPos2f(0.45, 0.16);
-    glutBitmapString(GLUT_BITMAP_TIMES_ROMAN_24, "World 3");
-    glPopMatrix();
-
-    glutSwapBuffers();
-}
-
-
-
-
 void game_loop(int argc, char** argv) {
     // INITIALIZATION //
     curl_global_init(CURL_GLOBAL_DEFAULT);
@@ -3138,10 +3042,7 @@ void game_loop(int argc, char** argv) {
     return 0;
 }
 
-
-
 int main(int argc, char** argv) {
-//initializes window and display length
 initializeMainMenu(&argc, argv);
 if(launchCraft){
 game_loop(argc, **argv);

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <time.h>
 #include "auth.h"
+#include "mainMenu.h"
 #include "client.h"
 #include "config.h"
 #include <stdbool.h>
@@ -156,11 +157,7 @@ typedef struct {
     Block copy1;
 } Model;
 
-static int launchCraft;
-//used as an additional check for the load save menu so it will
-//fire the correct events on click and not the ones for main menu
-static int loadSaveMenuLaunched;
-static int disableMainMenuClicks;
+
 static Model model;
 static Model *g = &model;
 
@@ -2145,23 +2142,7 @@ void on_light() {
     }
 }
 
-void renderButtonBackground(void)
-{
-glColor3f (0.5, 0.5, 0.5);
-glBegin(GL_POLYGON);
-glVertex3f (0.30, 0.60, 0.0);
-glVertex3f (0.65, 0.60, 0.0);
-glVertex3f (0.65, 0.75, 0.0);
-glVertex3f (0.30, 0.75, 0.0);
-glEnd();
-}
 
-//determines the keys a user presses and does certain actaions based on them
-void processNormalKeys(unsigned char key, int x, int y) {
-
-	if (key == 27)
-		exit(0);
-}
 
 void on_left_click() {
     State *s = &g->players->state;
@@ -2680,67 +2661,6 @@ void reset_model() {
     g->time_changed = 1;
 }
 
-/** handles a users mouse click by getting the position of their click then executing an appropriate response
-*/
-void handleMouseClick(int button, int state,int x, int y){
-    //we float the values by screen height and width so we can fit them within our
-    //ortho matrix
-    float x1=x/(float)glutGet(GLUT_SCREEN_WIDTH);
-    float y1=y/(float)glutGet(GLUT_SCREEN_HEIGHT);
-    printf("x: %f \n",x1);
-     printf("y: %f \n",y1);
-    if(!loadSaveMenuLaunched){
-    if(((x1>=0.3 && x1<=0.65)&&(y1>=0.15 && y1<=0.3))){
-        launchCraft=1;
-        printf("Launch Craft Called \n");
-        glutLeaveMainLoop();
-    }
-    if(((x1>=0.3 && x1<=0.65)&&(y1>=0.45 && y1<=0.6))){
-        //TODO: clear the glut window and render a new screen that will allow the user to choose a saved world or start a new one
-        printf("Load Save Called \n");
-        x1=0;
-        y1=0;
-        renderLoadSaveMenu();
-        loadSaveMenuLaunched=1;
-    }
-    if(((x1>=0.3 && x1<=0.65)&&(y1>=0.75 && y1<=0.9))){
-         printf("Exit Called \n");
-        exit(0);
-    }
-    //loadSaveMenuLaunched ensures we won't call any main menu clicks while on load save
-    }else if(loadSaveMenuLaunched){
-        //we need this boolean as clicking in GLUT happens in two parts onclick and on release
-        //becasue of this this method gets called twice on the menu and this boolean ensures we aren't immediately
-        //loading a world when clicking load save
-        if(disableMainMenuClicks){
-        if(((x1>=0.05 && x1<=0.15)&&(y1>=0.01 && y1<=0.4))){
-            //back
-            printf("back called \n");
-            renderMainMenu();
-            loadSaveMenuLaunched=0;
-            disableMainMenuClicks=0;
-        }
-        if(((x1>=0.3 && x1<=0.65)&&(y1>=0.15 && y1<=0.3))){
-            //World1
-             launchCraft=1;
-             printf("Load World 1 \n");
-             glutLeaveMainLoop();
-            
-        }
-        if(((x1>=0.3 && x1<=0.65)&&(y1>=0.45 && y1<=0.6))){
-            //world2
-            printf("Load World 2 \n");
-        }
-        if(((x1>=0.3 && x1<=0.65)&&(y1>=0.75 && y1<=0.9))){
-            //world3
-            printf("Load World 3 \n");
-        }
-        }else{
-            disableMainMenuClicks=1;
-        }
-    }
-}
-
 void renderLoadButtonBackground(void)
 {
 glColor3f (0.5, 0.5, 0.5);
@@ -2834,70 +2754,7 @@ void renderLoadSaveMenu(void){
     glutSwapBuffers();
 }
 
-void renderMainMenu(void){
-     //initializes the matrix and ortho so we can draw
-    glClearColor(0.0f, 0.0f, 0.0f, 0.5f);
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-    glMatrixMode(GL_PROJECTION);
-    glLoadIdentity();
-    glOrtho(0.0, 1.0, 0.0, 1.0, -1.0, 1.0);
-
-    glMatrixMode(GL_MODELVIEW);
-    glLoadIdentity();
-
-//creates the title
-    glPushMatrix();
-    glLoadIdentity();
-    glColor3f(1.0f,1.0f,1.0f);
-    glRasterPos2f(0.46, 0.90);
-    glutBitmapString(GLUT_BITMAP_TIMES_ROMAN_24, "CRAFT");
-    glPopMatrix();
-
-//first button
-    glPushMatrix();
-    glTranslatef(0.0, 0.1, 0.0);
-    renderButtonBackground();
-    glPopMatrix();
-
-//first button text
-    glPushMatrix();
-    glLoadIdentity();
-    glColor3f(1.0f,1.0f,1.0f);
-    glRasterPos2f(0.45, 0.76);
-    glutBitmapString(GLUT_BITMAP_TIMES_ROMAN_24, "Play Game");
-    glPopMatrix();
-
-//second button
-    glPushMatrix();
-    glTranslatef(0.0, -0.2, 0.0);
-    renderButtonBackground();
-    glPopMatrix();
-
-//second button text
-    glPushMatrix();
-    glLoadIdentity();
-    glColor3f(1.0f,1.0f,1.0f);
-    glRasterPos2f(0.45, 0.46);
-    glutBitmapString(GLUT_BITMAP_TIMES_ROMAN_24, "Load Save");
-    glPopMatrix();
-
-//third button
-    glPushMatrix();
-    glTranslatef(0.0, -0.5, 0.0);
-    renderButtonBackground();
-    glPopMatrix();
-
-//third buton text
-    glPushMatrix();
-    glLoadIdentity();
-    glColor3f(1.0f,1.0f,1.0f);
-    glRasterPos2f(0.45, 0.16);
-    glutBitmapString(GLUT_BITMAP_TIMES_ROMAN_24, "Exit Game");
-    glPopMatrix();
-
-    glutSwapBuffers();
-}
 
 
 void game_loop(int argc, char** argv) {
@@ -3285,17 +3142,7 @@ void game_loop(int argc, char** argv) {
 
 int main(int argc, char** argv) {
 //initializes window and display length
-glutInit(&argc, argv);
-glutInitDisplayMode (GLUT_SINGLE | GLUT_RGB);
-glutInitWindowSize (glutGet(GLUT_SCREEN_WIDTH), glutGet(GLUT_SCREEN_HEIGHT));
-glutInitWindowPosition (0, 0);
-glutCreateWindow ("Craft menu");
-//ensures we just exit the glut loop not close the program so we can still launch craft
-glutSetOption(GLUT_ACTION_ON_WINDOW_CLOSE, GLUT_ACTION_CONTINUE_EXECUTION);
-glutDisplayFunc(renderMainMenu);
-glutKeyboardFunc(processNormalKeys);
-glutMouseFunc(handleMouseClick);
-glutMainLoop();
+initializeMainMenu(&argc, argv);
 if(launchCraft){
 game_loop(argc, **argv);
 }

--- a/src/mainMenu.c
+++ b/src/mainMenu.c
@@ -1,0 +1,169 @@
+#include "mainMenu.h"
+#include <stdbool.h>
+#include <GL/glut.h>
+#include <GL/freeglut.h>
+
+int launchCraft;
+//used as an additional check for the load save menu so it will
+//fire the correct events on click and not the ones for main menu
+static int loadSaveMenuLaunched;
+static int disableMainMenuClicks;
+
+void initializeMainMenu(int argc, char** argv){
+glutInit(&argc, argv);
+glutInitDisplayMode (GLUT_SINGLE | GLUT_RGB);
+glutInitWindowSize (glutGet(GLUT_SCREEN_WIDTH), glutGet(GLUT_SCREEN_HEIGHT));
+glutInitWindowPosition (0, 0);
+glutCreateWindow ("Craft menu");
+//ensures we just exit the glut loop not close the program so we can still launch craft
+glutSetOption(GLUT_ACTION_ON_WINDOW_CLOSE, GLUT_ACTION_CONTINUE_EXECUTION);
+glutDisplayFunc(renderMainMenu);
+glutKeyboardFunc(processNormalKeys);
+glutMouseFunc(handleMouseClick);
+glutMainLoop();
+}
+
+void renderMainMenu(void){
+     //initializes the matrix and ortho so we can draw
+    glClearColor(0.0f, 0.0f, 0.0f, 0.5f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    glMatrixMode(GL_PROJECTION);
+    glLoadIdentity();
+    glOrtho(0.0, 1.0, 0.0, 1.0, -1.0, 1.0);
+
+    glMatrixMode(GL_MODELVIEW);
+    glLoadIdentity();
+
+//creates the title
+    glPushMatrix();
+    glLoadIdentity();
+    glColor3f(1.0f,1.0f,1.0f);
+    glRasterPos2f(0.46, 0.90);
+    glutBitmapString(GLUT_BITMAP_TIMES_ROMAN_24, "CRAFT");
+    glPopMatrix();
+
+//first button
+    glPushMatrix();
+    glTranslatef(0.0, 0.1, 0.0);
+    renderButtonBackground();
+    glPopMatrix();
+
+//first button text
+    glPushMatrix();
+    glLoadIdentity();
+    glColor3f(1.0f,1.0f,1.0f);
+    glRasterPos2f(0.45, 0.76);
+    glutBitmapString(GLUT_BITMAP_TIMES_ROMAN_24, "Play Game");
+    glPopMatrix();
+
+//second button
+    glPushMatrix();
+    glTranslatef(0.0, -0.2, 0.0);
+    renderButtonBackground();
+    glPopMatrix();
+
+//second button text
+    glPushMatrix();
+    glLoadIdentity();
+    glColor3f(1.0f,1.0f,1.0f);
+    glRasterPos2f(0.45, 0.46);
+    glutBitmapString(GLUT_BITMAP_TIMES_ROMAN_24, "Load Save");
+    glPopMatrix();
+
+//third button
+    glPushMatrix();
+    glTranslatef(0.0, -0.5, 0.0);
+    renderButtonBackground();
+    glPopMatrix();
+
+//third buton text
+    glPushMatrix();
+    glLoadIdentity();
+    glColor3f(1.0f,1.0f,1.0f);
+    glRasterPos2f(0.45, 0.16);
+    glutBitmapString(GLUT_BITMAP_TIMES_ROMAN_24, "Exit Game");
+    glPopMatrix();
+
+    glutSwapBuffers();
+}
+
+void renderButtonBackground(void)
+{
+glColor3f (0.5, 0.5, 0.5);
+glBegin(GL_POLYGON);
+glVertex3f (0.30, 0.60, 0.0);
+glVertex3f (0.65, 0.60, 0.0);
+glVertex3f (0.65, 0.75, 0.0);
+glVertex3f (0.30, 0.75, 0.0);
+glEnd();
+}
+
+//determines the keys a user presses and does certain actaions based on them
+void processNormalKeys(unsigned char key, int x, int y) {
+
+	if (key == 27)
+		exit(0);
+}
+
+/** handles a users mouse click by getting the position of their click then executing an appropriate response
+*/
+void handleMouseClick(int button, int state,int x, int y){
+    //we float the values by screen height and width so we can fit them within our
+    //ortho matrix
+    float x1=x/(float)glutGet(GLUT_SCREEN_WIDTH);
+    float y1=y/(float)glutGet(GLUT_SCREEN_HEIGHT);
+    printf("x: %f \n",x1);
+     printf("y: %f \n",y1);
+    if(!loadSaveMenuLaunched){
+    if(((x1>=0.3 && x1<=0.65)&&(y1>=0.15 && y1<=0.3))){
+        launchCraft=1;
+        printf("Launch Craft Called \n");
+        glutLeaveMainLoop();
+    }
+    if(((x1>=0.3 && x1<=0.65)&&(y1>=0.45 && y1<=0.6))){
+        //TODO: clear the glut window and render a new screen that will allow the user to choose a saved world or start a new one
+        printf("Load Save Called \n");
+        x1=0;
+        y1=0;
+        renderLoadSaveMenu();
+        loadSaveMenuLaunched=1;
+    }
+    if(((x1>=0.3 && x1<=0.65)&&(y1>=0.75 && y1<=0.9))){
+         printf("Exit Called \n");
+        exit(0);
+    }
+    //loadSaveMenuLaunched ensures we won't call any main menu clicks while on load save
+    }else if(loadSaveMenuLaunched){
+        //we need this boolean as clicking in GLUT happens in two parts onclick and on release
+        //becasue of this this method gets called twice on the menu and this boolean ensures we aren't immediately
+        //loading a world when clicking load save
+        if(disableMainMenuClicks){
+        if(((x1>=0.05 && x1<=0.15)&&(y1>=0.01 && y1<=0.4))){
+            //back
+            printf("back called \n");
+            renderMainMenu();
+            loadSaveMenuLaunched=0;
+            disableMainMenuClicks=0;
+        }
+        if(((x1>=0.3 && x1<=0.65)&&(y1>=0.15 && y1<=0.3))){
+            //World1
+             launchCraft=1;
+             printf("Load World 1 \n");
+             glutLeaveMainLoop();
+            
+        }
+        if(((x1>=0.3 && x1<=0.65)&&(y1>=0.45 && y1<=0.6))){
+            //world2
+            printf("Load World 2 \n");
+        }
+        if(((x1>=0.3 && x1<=0.65)&&(y1>=0.75 && y1<=0.9))){
+            //world3
+            printf("Load World 3 \n");
+        }
+        }else{
+            disableMainMenuClicks=1;
+        }
+    }
+}
+

--- a/src/mainMenu.c
+++ b/src/mainMenu.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <GL/glut.h>
 #include <GL/freeglut.h>
+#include "loadSaveMenu.h"
 
 int launchCraft;
 //used as an additional check for the load save menu so it will

--- a/src/mainMenu.h
+++ b/src/mainMenu.h
@@ -1,0 +1,6 @@
+ int launchCraft;
+void initializeMainMenu(int argc, char** argv);
+void renderMainMenu();
+void processNormalKeys(unsigned char key, int x, int y);
+void handleMouseClick(int button, int state,int x, int y);
+void renderButtonBackground();


### PR DESCRIPTION
Added the ranges in for the buttons so we could determine when the user clicked on a menu button. Disabled the main menu ranges during this time so we weren't calling two sets of methods. Added functionality to back and load world 1 so users can load something from the page and return to the main menu. The other load worlds will serve as a skeleton for where we will later implement loading and/or creating other worlds from the save system.